### PR TITLE
fix: ping 1841 topic page preview "this was deleted"

### DIFF
--- a/src/hooks/core/chat/useFetchChannelHook.ts
+++ b/src/hooks/core/chat/useFetchChannelHook.ts
@@ -118,8 +118,16 @@ const useFetchChannelHook = () => {
       const isLocationChannel = channel?.channel_type === 2 || channel?.type_channel === 2;
       const isDeletedMessage = channel?.firstMessage?.type === 'deleted';
       const isSelfChatChannel = channel?.type === 'messaging' && channel?.members?.length < 2;
+      const isCommunityChannel = channel?.type === 'topics';
+      const isDeletedCommunityMessage = channel?.messages[channel?.messages?.length - 1]?.text
+        ?.toLowerCase()
+        ?.includes('this message was deleted');
 
-      return !isLocationChannel && !(isDeletedMessage || isSelfChatChannel);
+      return (
+        !isLocationChannel &&
+        !(isDeletedMessage || isSelfChatChannel) &&
+        !((isDeletedMessage || isDeletedCommunityMessage) && isCommunityChannel)
+      );
     });
 
     filteredChannels.forEach(async (channel) => {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Updated the `useFetchChannelHook` function to improve chat channel filtering. Channels that are community channels and contain a last message stating "this message was deleted" will now be appropriately filtered out. This change enhances user experience by preventing display of irrelevant or inappropriate channels.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->