### PR TITLE
Feat/viewposttime in topic feeds

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -979,7 +979,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: fa8275d5086566e22a26ddc385ab5772e7f9b1bd
-  FBReactNativeSpec: 67b2d6bbfc2d9d96dbbf28ccd1a4a2a97c04a29f
+  FBReactNativeSpec: 35c98e8661ee0c117e11e7cfe02938caad0fa85b
   Firebase: fffddd0bab8677d07376538365faa93ff3889b39
   FirebaseABTesting: e66f1f80747792630d9b292966de206d5df9853b
   FirebaseAnalytics: 4641d7ae4220174f6ca5626163ffc5de2e90391e
@@ -1095,4 +1095,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: afc99f05b45ed46beccf19346460228e62656155
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.13.0

--- a/src/screens/FeedScreen/hooks/useCoreFeed.js
+++ b/src/screens/FeedScreen/hooks/useCoreFeed.js
@@ -4,21 +4,15 @@ import axios from 'axios';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import StorageUtils from '../../../utils/storage';
-import dimen from '../../../utils/dimen';
+import useViewPostTimeHook from './useViewPostTimeHook';
 import {Context} from '../../../context';
 import {FEEDS_CACHE} from '../../../utils/cache/constant';
-import {SOURCE_FEED_TAB} from '../../../utils/constants';
 import {checkIsHasColor, hexToRgb} from '../../../utils/colors';
 import {downVote, upVote} from '../../../service/vote';
-import {getFeedDetail, getMainFeedV2WithTargetFeed, viewTimePost} from '../../../service/post';
+import {getFeedDetail, getMainFeedV2WithTargetFeed} from '../../../service/post';
 import {listFeedColor} from '../../../configs/FeedColor';
 import {saveToCache} from '../../../utils/cache';
-import {
-  setFeedByIndex,
-  setMainFeeds,
-  setTimer,
-  setViewPostTimeIndex
-} from '../../../context/actions/feeds';
+import {setFeedByIndex, setMainFeeds, setTimer} from '../../../context/actions/feeds';
 
 const useCoreFeed = () => {
   const [loading, setLoading] = React.useState(false);
@@ -34,6 +28,12 @@ const useCoreFeed = () => {
   const {feeds, timer, viewPostTimeIndex} = feedsContext;
   const {myProfile} = profileContext;
   const {bottom} = useSafeAreaInsets();
+
+  const {sendViewPostTimeWithFeeds, updateViewPostTime, isSamePostViewed} = useViewPostTimeHook(
+    dispatch,
+    timer,
+    viewPostTimeIndex
+  );
 
   const getDataFeeds = async (offsetFeed = 0, useLoading = false, targetFeed = null) => {
     setCountStack(null);
@@ -222,28 +222,7 @@ const useCoreFeed = () => {
   };
 
   const sendViewPostTime = async (withResetTime = false) => {
-    const currentTime = new Date();
-    const diffTime = currentTime.getTime() - timer.getTime();
-    const id = feeds?.[viewPostTimeIndex]?.id;
-    if (!id) return;
-
-    viewTimePost(id, diffTime, SOURCE_FEED_TAB);
-    if (withResetTime) setTimer(new Date(), dispatch);
-  };
-
-  const getCurrentPostViewed = (momentumEvent) => {
-    const {y} = momentumEvent.nativeEvent.contentOffset;
-    const shownIndex = Math.ceil(y / dimen.size.FEED_CURRENT_ITEM_HEIGHT);
-    return shownIndex;
-  };
-
-  const updateViewPostTime = (momentumEvent) => {
-    setViewPostTimeIndex(getCurrentPostViewed(momentumEvent), dispatch);
-    setTimer(new Date(), dispatch);
-  };
-
-  const isSamePostViewed = (momentumEvent) => {
-    return getCurrentPostViewed(momentumEvent) === viewPostTimeIndex;
+    sendViewPostTimeWithFeeds(feeds, withResetTime);
   };
 
   return {
@@ -272,6 +251,7 @@ const useCoreFeed = () => {
     onDeleteBlockedPostCompleted,
     saveSearchHeight,
     sendViewPostTime,
+    sendViewPostTimeWithFeeds,
     setDownVote,
     setIsLastPage,
     setMainFeeds,

--- a/src/screens/FeedScreen/hooks/useViewPostTimeHook.ts
+++ b/src/screens/FeedScreen/hooks/useViewPostTimeHook.ts
@@ -1,0 +1,46 @@
+import dimen from '../../../utils/dimen';
+import {SOURCE_FEED_TAB} from '../../../utils/constants';
+import {setTimer, setViewPostTimeIndex} from '../../../context/actions/feeds';
+import {viewTimePost} from '../../../service/post';
+
+const useViewPostTimeHook = (dispatch, timer, viewPostTimeIndex) => {
+  const sendViewPostTimeWithFeeds = async (feedsParam = [], withResetTime = false) => {
+    const currentTime = new Date();
+    const diffTime = currentTime.getTime() - timer.getTime();
+    const id = (feedsParam?.[viewPostTimeIndex] as any)?.id;
+    if (!id) return;
+
+    viewTimePost(id, diffTime, SOURCE_FEED_TAB);
+    if (withResetTime) setTimer(new Date(), dispatch);
+  };
+
+  const getCurrentPostViewed = (momentumEvent) => {
+    const {y} = momentumEvent.nativeEvent.contentOffset;
+    const shownIndex = Math.ceil(y / dimen.size.FEED_CURRENT_ITEM_HEIGHT);
+    return shownIndex;
+  };
+
+  const updateViewPostTime = (momentumEvent) => {
+    setViewPostTimeIndex(getCurrentPostViewed(momentumEvent), dispatch);
+    setTimer(new Date(), dispatch);
+  };
+
+  const isSamePostViewed = (momentumEvent) => {
+    return getCurrentPostViewed(momentumEvent) === viewPostTimeIndex;
+  };
+
+  const onWillSendViewPostTime = (event, feedParams) => {
+    if (isSamePostViewed(event)) return;
+    sendViewPostTimeWithFeeds(feedParams);
+    updateViewPostTime(event);
+  };
+
+  return {
+    sendViewPostTimeWithFeeds,
+    updateViewPostTime,
+    isSamePostViewed,
+    onWillSendViewPostTime
+  };
+};
+
+export default useViewPostTimeHook;

--- a/src/screens/TopicPageScreen/index.js
+++ b/src/screens/TopicPageScreen/index.js
@@ -2,32 +2,33 @@ import * as React from 'react';
 import _ from 'lodash';
 import SimpleToast from 'react-native-simple-toast';
 import {Animated, Platform, StyleSheet} from 'react-native';
+import {SafeAreaProvider, useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useNavigation, useRoute} from '@react-navigation/native';
 
-import {SafeAreaProvider, useSafeAreaInsets} from 'react-native-safe-area-context';
 import BlockComponent from '../../components/BlockComponent';
 import ButtonAddPostTopic from '../../components/Button/ButtonAddPostTopic';
 import MemoizedListComponent from './MemoizedListComponent';
+import NavHeader from './elements/NavHeader';
 import ShareUtils from '../../utils/share';
 import TiktokScroll from '../../components/TiktokScroll';
 import TopicPageStorage from '../../utils/storage/custom/topicPageStorage';
 import dimen from '../../utils/dimen';
 import removePrefixTopic from '../../utils/topics/removePrefixTopic';
+import useCoreFeed from '../FeedScreen/hooks/useCoreFeed';
+import useViewPostTimeHook from '../FeedScreen/hooks/useViewPostTimeHook';
+import useOnBottomNavigationTabPressHook, {
+  LIST_VIEW_TYPE
+} from '../../hooks/navigation/useOnBottomNavigationTabPressHook';
 import {Context} from '../../context';
 import {downVote, upVote} from '../../service/vote';
 import {getFeedDetail} from '../../service/post';
 import {getTopicPages} from '../../service/topicPages';
+import {getTopics, getUserTopic} from '../../service/topics';
 import {getUserId} from '../../utils/users';
 import {linkContextScreenParamBuilder} from '../../utils/navigation/paramBuilder';
+import {normalize, normalizeFontSizeByWidth} from '../../utils/fonts';
 import {setFeedByIndex, setTopicFeedByIndex, setTopicFeeds} from '../../context/actions/feeds';
 import {withInteractionsManaged} from '../../components/WithInteractionManaged';
-import {normalize, normalizeFontSizeByWidth} from '../../utils/fonts';
-import useOnBottomNavigationTabPressHook, {
-  LIST_VIEW_TYPE
-} from '../../hooks/navigation/useOnBottomNavigationTabPressHook';
-import NavHeader from './elements/NavHeader';
-import useCoreFeed from '../FeedScreen/hooks/useCoreFeed';
-import {getTopics, getUserTopic} from '../../service/topics';
 
 const styles = StyleSheet.create({
   parentContainer: {
@@ -68,11 +69,16 @@ const TopicPageScreen = (props) => {
     ? feedsContext.topicFeeds.filter((feed) => feed?.topics?.includes(topicName))
     : [];
   const mainFeeds = feedsContext.feeds;
+  const {timer, viewPostTimeIndex} = feedsContext;
+
   const [offset, setOffset] = React.useState(0);
   const [client] = React.useContext(Context).client;
   const refBlockComponent = React.useRef();
   const scrollY = React.useRef(new Animated.Value(0)).current;
   const {mappingColorFeed} = useCoreFeed();
+
+  const {onWillSendViewPostTime} = useViewPostTimeHook(dispatch, timer, viewPostTimeIndex);
+
   const {listRef} = useOnBottomNavigationTabPressHook(LIST_VIEW_TYPE.TIKTOK_SCROLL, onRefresh);
 
   const topicWithPrefix = route.params.id;
@@ -422,6 +428,7 @@ const TopicPageScreen = (props) => {
         snap
         contentOffset={{x: 0, y: topPosition}}
         contentInsetAdjustmentBehavior={feeds?.length > 1 ? 'automatic' : 'never'}
+        onMomentumScrollEnd={(event) => onWillSendViewPostTime(event, feeds)}
       />
       <ButtonAddPostTopic topicName={topicName} onRefresh={onRefresh} />
       <BlockComponent


### PR DESCRIPTION
This commit includes
1. Refactor view post time into a single hook
2. Implement view post time on topic feed
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Introduced a new custom hook `useViewPostTimeHook` to encapsulate the logic related to viewing post time in topic feeds, improving code modularity and maintainability.
- New Feature: Updated the `FeedScreen` and `TopicPageScreen` to use the new `useViewPostTimeHook`, enhancing the user experience by providing more accurate view post times.
- Refactor: Replaced `sendViewPostTime` function with `sendViewPostTimeWithFeeds` for better handling of view post time functionality with feeds.
- New Feature: Added a new `NavHeader` component to improve navigation within the application.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->