### PR TITLE
fix: keyboard wrapper inset top

### DIFF
--- a/src/navigations/KeyboardWrapper.tsx
+++ b/src/navigations/KeyboardWrapper.tsx
@@ -12,10 +12,7 @@ const KeyboardWrapper = ({children}: Props): JSX.Element => {
   const insets = useSafeAreaInsets();
 
   return (
-    <KeyboardAvoidingView
-      style={{flex: 1}}
-      keyboardVerticalOffset={insets.top}
-      behavior={isIos ? 'padding' : undefined}>
+    <KeyboardAvoidingView style={{flex: 1}} behavior={isIos ? 'padding' : undefined}>
       {children}
     </KeyboardAvoidingView>
   );


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated the `KeyboardWrapper` component in the navigation system. The keyboard's top inset will no longer be applied to the view, providing a more streamlined user experience when interacting with input fields. This change enhances the visual consistency across different screens and improves overall usability.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->