### PR TITLE
Fix: member counts default value

### DIFF
--- a/src/screens/TopicPageScreen/elements/TopicDomainHeader.js
+++ b/src/screens/TopicPageScreen/elements/TopicDomainHeader.js
@@ -38,12 +38,10 @@ const TopicDomainHeader = (props) => {
             height: normalize(8)
           }}
         />
-        {props?.initialData?.memberCount === undefined && props.isLoading ? (
+        {memberCount === undefined && props.isLoading ? (
           <Shimmer height={10} width={normalize(25)} />
         ) : (
-          <Text style={styles.domainMember(shouldDisplay)}>
-            {props?.initialData?.memberCount || memberCount}
-          </Text>
+          <Text style={styles.domainMember(shouldDisplay)}>{memberCount}</Text>
         )}
         <Text style={styles.domainMember(shouldDisplay)}> Members</Text>
       </View>

--- a/src/screens/TopicPageScreen/index.js
+++ b/src/screens/TopicPageScreen/index.js
@@ -63,7 +63,7 @@ const TopicPageScreen = (props) => {
   const [topicId, setTopicId] = React.useState('');
   const [isFollow, setIsFollow] = React.useState(params.isFollowing);
   const [topicDetail, setTopicDetail] = React.useState({});
-  const [memberCount, setMemberCount] = React.useState(0);
+  const [memberCount, setMemberCount] = React.useState(params.memberCount);
   const [isHeaderHide, setIsHeaderHide] = React.useState(false);
   const [feedsContext, dispatch] = React.useContext(Context).feeds;
   const feeds = feedsContext.topicFeeds


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- Refactor: Simplified the handling of `memberCount` in `TopicDomainHeader` by removing unnecessary checks.
- Bug Fix: Updated the initial state of `memberCount` in `TopicPageScreen` to use the provided `params.memberCount` value, improving the accuracy of the initial rendering of the component.
---
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->