### PR TITLE
Ping 3072 - Fix toast color

### DIFF
--- a/src/configs/ToastConfig.js
+++ b/src/configs/ToastConfig.js
@@ -18,7 +18,7 @@ export const toastConfig = {
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: COLORS.signed_primary,
+    backgroundColor: COLORS.black75,
     alignItems: 'center',
     justifyContent: 'center',
     padding: 10,
@@ -31,7 +31,7 @@ const styles = StyleSheet.create({
 
 const styleAsNative = StyleSheet.create({
   container: {
-    backgroundColor: COLORS.signed_primary,
+    backgroundColor: COLORS.black75,
     borderRadius: 45,
     paddingHorizontal: 30,
     paddingVertical: 5,

--- a/src/utils/theme/index.js
+++ b/src/utils/theme/index.js
@@ -54,7 +54,8 @@ export const COLORS = {
   holytosca15percent: '#00ADB526',
   holytosca30percent: '#00ADB54D',
   black50: 'rgba(0, 0, 0, 0.5)',
-  gray5: '#E8EBED'
+  gray5: '#E8EBED',
+  black75: 'rgba(0, 0, 0, 0.75)'
 };
 export const SIZES = {
   // global sizes


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Style: Introduced a new color value (`black75`) to the theme palette.
- Refactor: Updated the background color of toast notifications from `signed_primary` to `black75` for improved visibility and consistency with the overall application theme.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->