### PR TITLE
fix: discovery tap behavior and safe area follower

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -24,7 +24,7 @@ Btn.propTypes = {
   disabled: PropTypes.bool,
   children: PropTypes.node,
   onPress: PropTypes.func,
-  style: PropTypes.object,
+  styles: PropTypes.object,
   textStyling: PropTypes.object
 };
 

--- a/src/navigations/root-stack.js
+++ b/src/navigations/root-stack.js
@@ -139,16 +139,15 @@ const withSafeAreaView = (Component) => {
     </SafeAreaView>
   );
 };
+const withKeyboardWrapper = (Component) => {
+  return (props) => (
+    <KeyboardWrapper>
+      <Component {...props} />
+    </KeyboardWrapper>
+  );
+};
 
 const AuthenticatedNavigator = () => {
-  const withKeyboardWrapper = (Component) => {
-    return (props) => (
-      <KeyboardWrapper>
-        <Component {...props} />
-      </KeyboardWrapper>
-    );
-  };
-
   return (
     <OneSignalNavigator>
       <AuthenticatedStack.Navigator initialRouteName="HomeTabs">
@@ -213,7 +212,7 @@ const AuthenticatedNavigator = () => {
         />
         <AuthenticatedStack.Screen
           name="Followers"
-          component={withKeyboardWrapper(FollowersScreen)}
+          component={withSafeAreaView(withKeyboardWrapper(FollowersScreen))}
           options={{
             headerShown: false
           }}

--- a/src/screens/CreatePost/elements/SheetCloseBtn.js
+++ b/src/screens/CreatePost/elements/SheetCloseBtn.js
@@ -27,7 +27,9 @@ const SheetCloseBtn = ({backRef, goBack, continueToEdit}) => {
         <Gap style={styles.gap(10)} />
         <Button
           onPress={goBack}
-          style={{backgroundColor: COLORS.porcelain}}
+          styles={{
+            backgroundColor: COLORS.porcelain
+          }}
           textStyling={{color: COLORS.black}}>
           <Text>Discard post</Text>
         </Button>

--- a/src/screens/DiscoveryScreenV2/fragment/DomainFragment.js
+++ b/src/screens/DiscoveryScreenV2/fragment/DomainFragment.js
@@ -272,6 +272,7 @@ const DomainFragment = ({
         renderItem={renderItemList}
         onEndReached={() => fetchData()}
         onEndReachedThreshold={0.6}
+        keyboardShouldPersistTaps="handled"
       />
     );
   };

--- a/src/screens/DiscoveryScreenV2/fragment/TopicFragment.js
+++ b/src/screens/DiscoveryScreenV2/fragment/TopicFragment.js
@@ -240,6 +240,7 @@ const TopicFragment = ({
         keyExtractor={(item, index) => index.toString()}
         onEndReached={() => fetchData()}
         onEndReachedThreshold={0.6}
+        keyboardShouldPersistTaps="handled"
       />
     );
   };

--- a/src/screens/DiscoveryScreenV2/fragment/UsersFragment.js
+++ b/src/screens/DiscoveryScreenV2/fragment/UsersFragment.js
@@ -9,7 +9,6 @@ import DiscoveryTitleSeparator from '../elements/DiscoveryTitleSeparator';
 import DomainList from '../elements/DiscoveryItemList';
 import LoadingWithoutModal from '../../../components/LoadingWithoutModal';
 import RecentSearch from '../elements/RecentSearch';
-import useIsReady from '../../../hooks/useIsReady';
 import {COLORS} from '../../../utils/theme';
 import {Context} from '../../../context/Store';
 import {fonts} from '../../../utils/fonts';
@@ -274,6 +273,7 @@ const UsersFragment = ({
         keyExtractor={(item, index) => index.toString()}
         onEndReached={() => fetchData()}
         onEndReachedThreshold={0.6}
+        keyboardShouldPersistTaps="handled"
       />
     );
   };

--- a/src/screens/Followings/index.js
+++ b/src/screens/Followings/index.js
@@ -1,22 +1,18 @@
 import * as React from 'react';
 
-import {ScrollView, StyleSheet} from 'react-native';
 import PropTypes from 'prop-types';
 import UsersFragment from '../DiscoveryScreenV2/fragment/UsersFragment';
-import {COLORS} from '../../utils/theme';
 
 const Followings = ({dataFollower = [], isLoading, setDataFollower = () => {}}) => {
   return (
-    <ScrollView style={styles.container} contentContainerStyle={{flexGrow: 1}}>
-      <UsersFragment
-        followedUsers={dataFollower}
-        setFollowedUsers={setDataFollower}
-        isLoadingDiscoveryUser={isLoading}
-        showRecentSearch={true}
-        withoutRecent={true}
-        isUser={true}
-      />
-    </ScrollView>
+    <UsersFragment
+      followedUsers={dataFollower}
+      setFollowedUsers={setDataFollower}
+      isLoadingDiscoveryUser={isLoading}
+      showRecentSearch={true}
+      withoutRecent={true}
+      isUser={true}
+    />
   );
 };
 
@@ -27,7 +23,3 @@ Followings.propTypes = {
 };
 
 export default Followings;
-
-const styles = StyleSheet.create({
-  container: {height: '100%', backgroundColor: COLORS.white}
-});

--- a/src/screens/ProfileScreen/elements/BottomSheetBio.js
+++ b/src/screens/ProfileScreen/elements/BottomSheetBio.js
@@ -72,7 +72,6 @@ const styles = StyleSheet.create({
     marginTop: dimen.normalizeDimen(7)
   },
   button: {
-    marginTop: 33,
     backgroundColor: COLORS.signed_primary
   },
   textStyling: {


### PR DESCRIPTION
on this PR
1. fix safe area view on follower screen
after: 
<img width="163" alt="image" src="https://github.com/BetterSocial/mobileapp/assets/13555051/8f0b477e-dfb2-4dd5-ab67-e565ebac001d">

2. fix tap behavior on discovery, following, and follower
before: https://helioapp.slack.com/archives/C065C3K659Q/p1705548872139979

https://github.com/BetterSocial/mobileapp/assets/13555051/6610494f-65fc-4328-8707-0999d4462489


3. fix discard post style
before: https://pingsocial.atlassian.net/browse/PING-3434
<img width="321" alt="image" src="https://github.com/BetterSocial/mobileapp/assets/13555051/d7c90d52-75ec-444c-afda-dcf544a5463c">

4. fix edit prompt style
before: https://pingsocial.atlassian.net/browse/PING-3434
<img width="317" alt="image" src="https://github.com/BetterSocial/mobileapp/assets/13555051/541688b2-0ace-40d6-86df-4e5d413c09df">
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated `Btn` and `SheetCloseBtn` components for better styling consistency. Note: This may affect components relying on the `style` prop.
- Refactor: Improved code structure in `AuthenticatedNavigator` by moving `withKeyboardWrapper` function to top level. Also, enhanced user interface by wrapping `FollowersScreen` with `withSafeAreaView`.
- New Feature: Enhanced user experience on `DomainFragment`, `TopicFragment`, and `UsersFragment` components by ensuring taps are handled correctly when keyboard is open.
- Refactor: Simplified `Followings` component by removing unnecessary `ScrollView` and directly rendering `UsersFragment`.
- Style: Adjusted vertical positioning of button in `BottomSheetBio` by removing `marginTop` property from style.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->