### PR TITLE
fix: add comment preview button color

### DIFF
--- a/src/components/Comments/WriteComment.js
+++ b/src/components/Comments/WriteComment.js
@@ -138,11 +138,7 @@ const WriteComment = ({
           </TouchableOpacity>
         ) : (
           <View style={styles.isViewOnlyIcon}>
-            <SendIcon
-              fillBackground={
-                !isCommentEnabled || loadingUser ? COLORS.gray : COLORS.signed_primary
-              }
-            />
+            <SendIcon type={CHAT_SIGNED} />
           </View>
         )}
       </View>


### PR DESCRIPTION
## Description
fix send button color on add preview comment from anon to signed primary color

## Screenshot
### Feed
![image](https://github.com/BetterSocial/mobileapp/assets/49477728/9923d861-3f90-4814-b299-97871a458a60)

### Profile
![image](https://github.com/BetterSocial/mobileapp/assets/49477728/b0823c0c-8d9b-4537-a65c-96c84fb8fc55)
![image](https://github.com/BetterSocial/mobileapp/assets/49477728/f897b574-44ce-4cce-ad8d-8a87b2b4918c)

### Community
![image](https://github.com/BetterSocial/mobileapp/assets/49477728/8ba3ee62-64ba-45d7-9cc7-f0020b0953e0)

### Other Profile
![image](https://github.com/BetterSocial/mobileapp/assets/49477728/1423e86d-4269-4c6d-997a-994c93bb76e7)

### PDP
Anonimity Off
![image](https://github.com/BetterSocial/mobileapp/assets/49477728/e5e09565-e230-4b92-8543-03d88833e3d0)

Anonimity On
![image](https://github.com/BetterSocial/mobileapp/assets/49477728/e8804820-df0a-45bb-b70e-c75193920b5f)

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated the `WriteComment` component to enhance the user interface. The comment send button now utilizes the `SendIcon` component with the `CHAT_SIGNED` type, providing a more consistent and visually appealing experience when interacting with the comments section.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->