### PR TITLE
fix: chat tab indicator broken ping 3560

### DIFF
--- a/src/components/AnonymousChat/child/ChannelImage.tsx
+++ b/src/components/AnonymousChat/child/ChannelImage.tsx
@@ -54,7 +54,8 @@ const ChannelImage = ({
       borderColor: COLORS.white,
       display: 'flex',
       justifyContent: 'center',
-      alignItems: 'center'
+      alignItems: 'center',
+      backgroundColor: COLORS.anon_primary
     },
     myPostNotificationImageContainer: {
       backgroundColor: isAnonymousTab ? COLORS.anon_primary : COLORS.signed_primary


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Style: Updated the visual appearance of the `ChannelImage` component in the Anonymous Chat. The component now has a new background color (`COLORS.anon_primary`) enhancing its visibility and user interaction.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->