### PR TITLE
Fix: notif post crash

### DIFF
--- a/src/components/PostPageDetail/index.js
+++ b/src/components/PostPageDetail/index.js
@@ -112,12 +112,11 @@ const PostPageDetailIdComponent = (props) => {
   };
   const initial = () => {
     const reactionCount = item?.reaction_counts;
-    if (JSON.stringify(reactionCount) !== '{}') {
+    if (JSON.stringify(reactionCount) !== '{}' && reactionCount) {
       let count = 0;
-      const {comment} = reactionCount;
       handleVote(reactionCount);
-      if (comment !== undefined) {
-        if (comment > 0) {
+      if (reactionCount?.comment !== undefined) {
+        if (reactionCount?.comment > 0) {
           setReaction(true);
           setTotalComment(getCountCommentWithChildInDetailPage(item.latest_reactions));
         }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Enhanced the `PostPageDetailIdComponent` to handle cases where `reactionCount` is empty or falsy, preventing potential crashes and improving application stability.
- Refactor: Updated the check for the existence of the `comment` property using optional chaining for better readability and error prevention when dealing with undefined or null values.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->