### PR TITLE
fix: remove default topic image when saving to DB

### DIFF
--- a/src/components/AnonymousChat/child/ChannelImage.tsx
+++ b/src/components/AnonymousChat/child/ChannelImage.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
-import {StyleSheet, View} from 'react-native';
 import FastImage from 'react-native-fast-image';
+import {StyleSheet, View} from 'react-native';
 
-import {BaseChannelItemTypeProps} from '../../../../types/component/AnonymousChat/BaseChannelItem.types';
-import {AnonUserInfo} from '../../../../types/service/AnonProfile.type';
-import ChatIcon from '../../../assets/chat-icon.png';
 import AnonymousProfile from '../../../assets/images/AnonymousProfile.png';
-import FeedIcon from '../../../assets/images/feed-icon.png';
-import useProfileHook from '../../../hooks/core/profile/useProfileHook';
-import dimen from '../../../utils/dimen';
-import {COLORS} from '../../../utils/theme';
 import ChannelAnonymousImage from './ChannelAnonymousImage';
 import ChannelAnonymousSubImage from './ChannelAnonymousSubImage';
+import ChatIcon from '../../../assets/chat-icon.png';
+import FeedIcon from '../../../assets/images/feed-icon.png';
+import dimen from '../../../utils/dimen';
+import useProfileHook from '../../../hooks/core/profile/useProfileHook';
+import {AnonUserInfo} from '../../../../types/service/AnonProfile.type';
+import {BaseChannelItemTypeProps} from '../../../../types/component/AnonymousChat/BaseChannelItem.types';
+import {COLORS} from '../../../utils/theme';
 
 export type ChannelImageProps = {
   mainPicture?: string;
@@ -58,7 +58,7 @@ const ChannelImage = ({
       backgroundColor: COLORS.anon_primary
     },
     myPostNotificationImageContainer: {
-      backgroundColor: isAnonymousTab ? COLORS.anon_primary : COLORS.signed_primary
+      backgroundColor: isAnonymousTab ? COLORS.anon_primary : COLORS.signed_secondary
     },
     anonPmNotificationImageContainer: {
       backgroundColor: COLORS.anon_primary
@@ -71,8 +71,8 @@ const ChannelImage = ({
       width: dimen.normalizeDimen(12),
       height: dimen.normalizeDimen(12)
     },
-    backgroundsigned_primary: {
-      backgroundColor: COLORS.signed_primary
+    backgroundsigned_secondary: {
+      backgroundColor: COLORS.signed_secondary
     }
   });
 
@@ -191,7 +191,7 @@ const ChannelImage = ({
             styles.postNotificationImage,
             isAnonymousTab
               ? styles.anonPmNotificationImageContainer
-              : styles.backgroundsigned_primary
+              : styles.backgroundsigned_secondary
           ]}>
           <FastImage source={ChatIcon} style={styles.chatIcon} />
         </View>

--- a/src/components/ChatList/elements/ChannelImage.style.ts
+++ b/src/components/ChatList/elements/ChannelImage.style.ts
@@ -44,6 +44,9 @@ export const channelImageStyles = StyleSheet.create({
   containersigned_primary: {
     backgroundColor: COLORS.signed_primary
   },
+  containersigned_secondary: {
+    backgroundColor: COLORS.signed_secondary
+  },
   badgeContainer: {
     position: 'absolute',
     display: 'flex',

--- a/src/components/ChatList/elements/ChannelImage.tsx
+++ b/src/components/ChatList/elements/ChannelImage.tsx
@@ -84,7 +84,7 @@ const Big: React.FC<ChannelImageMainProps> = ({type, image, style}) => {
 const Small: React.FC<ChannelImageBadgeProps> = ({type}) => {
   if (type === 'COMMUNITY') {
     return (
-      <View style={[styles.badgeContainer, styles.containersigned_primary]}>
+      <View style={[styles.badgeContainer, styles.containersigned_secondary]}>
         <FastImage
           source={CommunityIcon}
           resizeMode={FastImage.resizeMode.contain}
@@ -96,7 +96,7 @@ const Small: React.FC<ChannelImageBadgeProps> = ({type}) => {
 
   if (type === 'GROUP') {
     return (
-      <View style={[styles.badgeContainer, styles.containersigned_primary]}>
+      <View style={[styles.badgeContainer, styles.containersigned_secondary]}>
         <FastImage
           source={GroupIcon}
           resizeMode={FastImage.resizeMode.contain}

--- a/src/utils/string/StringUtils.js
+++ b/src/utils/string/StringUtils.js
@@ -342,7 +342,7 @@ const getChannelListInfo = (channel, selfSignUserId, selfAnonUserId) => {
   }
 
   if (channel?.type === 'topics') {
-    channelImage = channel?.channel_image ?? DEFAULT_TOPIC_PIC_PATH;
+    channelImage = channel?.channel_image;
     channelName = channel?.name;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Style: Updated the styling of the `ChannelImage` component, including changes to background colors and renaming of style definitions. This results in a visual update to the badges displayed in the UI for 'COMMUNITY' and 'GROUP' types.
- Refactor: Removed the default topic image when saving to the database, simplifying the assignment of `channelImage`. This change streamlines the handling of channel images in the backend.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->