### PR TITLE
Fix: notif crash pdp

### DIFF
--- a/src/components/PostPageDetail/index.js
+++ b/src/components/PostPageDetail/index.js
@@ -112,12 +112,11 @@ const PostPageDetailIdComponent = (props) => {
   };
   const initial = () => {
     const reactionCount = item?.reaction_counts;
-    if (JSON.stringify(reactionCount) !== '{}') {
+    if (JSON.stringify(reactionCount) !== '{}' && reactionCount) {
       let count = 0;
-      const {comment} = reactionCount;
       handleVote(reactionCount);
-      if (comment !== undefined) {
-        if (comment > 0) {
+      if (reactionCount?.comment !== undefined) {
+        if (reactionCount?.comment > 0) {
           setReaction(true);
           setTotalComment(getCountCommentWithChildInDetailPage(item.latest_reactions));
         }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Improved the reliability of the `PostPageDetailIdComponent` by refining the conditions for displaying reactions and comments. This ensures that reaction counts are only displayed when valid data is present, and comments are shown correctly even in edge cases. Users can now interact with posts more accurately and consistently.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->