### PR TITLE
fix: ping-3480 Going back to discovery doesnt save position/search staging

### DIFF
--- a/src/screens/DiscoveryScreenV2/elements/Search.js
+++ b/src/screens/DiscoveryScreenV2/elements/Search.js
@@ -89,6 +89,8 @@ const DiscoverySearch = ({
   };
 
   const handleOnClearText = () => {
+    handleFocus(true);
+    discoverySearchBarRef?.current?.focus();
     setSearchText('');
     setLastSearch('');
   };

--- a/src/screens/DiscoveryScreenV2/index.js
+++ b/src/screens/DiscoveryScreenV2/index.js
@@ -291,7 +291,15 @@ const DiscoveryScreenV2 = ({route}) => {
           news={discoveryDataNews}
         />
       );
-  }, [selectedScreen]);
+    return null;
+  }, [
+    selectedScreen,
+    searchText,
+    isLoadingDiscovery.topic,
+    isLoadingDiscovery.domain,
+    isLoadingDiscovery.news,
+    isLoadingDiscovery.user
+  ]);
 
   return (
     <DiscoveryContainer>


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Enhanced the user experience on the Discovery Screen by ensuring the search bar is properly focused when clearing the search text.
- Refactor: Improved the loading behavior of the Discovery Screen to return `null` under certain conditions, providing a smoother user experience during data loading.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->