### PR TITLE
fix: PING-3778 add hashtag after fallback topic name value

### DIFF
--- a/src/utils/string/StringUtils.js
+++ b/src/utils/string/StringUtils.js
@@ -347,7 +347,7 @@ const getChannelListInfo = (channel, selfSignUserId, selfAnonUserId) => {
     channelImage = channel?.channel_image;
     channelName = channel?.name;
     if (!channelName || channelName === '') {
-      channelName = removePrefixTopic(channel?.id);
+      channelName = `#${removePrefixTopic(channel?.id)}`;
     }
   }
 


### PR DESCRIPTION
# Helio PR Checklist

## Please review all of the following checks before making PR

- [x] Jika menambahkan sebuah komponen, apakah sudah dipastikan tidak ada komponen yang redundant, baik secara UI maupun fungsional?
- [x] Periksa apakah komponen yang dibuat reusable (contoh: membuat komponen View untuk membuat Divider antar section)
- [x] Periksa untuk penggunaan state management yang baik dan benar (contoh: Context, useState), terutama penggunaan local state untuk optimistic UI (Pengoperan state dan data melalui props dari parent ke children dan sebaliknya)
- [x] Pastikan komponen yang dibuat sudah sesuai dengan module yang ada terutama penamaan dan penempatan untuk meningkatkan readability dan maintainability.
- [x] Implementasi fallback error untuk menangani kesalahan tak terduga, mencegah aplikasi mengalami crash
- [x] Evaluasi kompleksitas kode dan perbaiki logika yang kompleks dengan memecahnya menjadi fungsi atau komponen yang lebih kecil dan lebih mudah dimengerti.
- [x] Apakah sudah resolve semua komentar dari CodeRabbit🐇?
- [x] Apakah semua unit tests sudah Pass/Success? (Tidak ada bypass)
- [x] Periksa semua perubahan teks Bahasa Inggris approved oleh Bastian?
- [x] Apakah sudah menggunakan normalized.dimen/ normalizeFontSize untuk semua perubahan style?
- [x] Pastikan untuk mengikuti [guidelines pembuatan komponen Guidelines About Loading and Layout](https://docs.google.com/document/d/1GHbvEtFrQmEQXYBV9dLrPI654n2DbPwS1qjedajLSiw/edit)

### Author's comment

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Updated the `getChannelListInfo` function in `StringUtils.js`. Now, if a channel name is not provided, it will automatically prepend a hashtag. This ensures consistency in the display of channel names across the application, even when a name isn't explicitly given.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->