### PR TITLE
[PING-3795] fix: discovery fetch after follow

### DIFF
--- a/src/screens/TopicPageScreen/elements/BottomSheetFollow.tsx
+++ b/src/screens/TopicPageScreen/elements/BottomSheetFollow.tsx
@@ -9,6 +9,9 @@ import {COLORS} from '../../../utils/theme';
 import {Button} from '../../../components/Button';
 import useChatClientHook from '../../../utils/getstream/useChatClientHook';
 import UserItem from './UserItem';
+import DiscoveryRepo from '../../../service/discovery';
+import DiscoveryAction from '../../../context/actions/discoveryAction';
+import {Context} from '../../../context';
 
 export type Follow = 'signed' | 'incognito' | '';
 
@@ -38,6 +41,7 @@ const BottomSheetFollow = forwardRef((props: BottomSheetFollowProps, ref: Ref<RB
     getTopicDetail,
     onClose
   } = props;
+  const [, discoveryDispatch] = (React.useContext(Context) as any)?.discovery;
   const {followTopic} = useChatClientHook();
 
   const handleFollowTopic = async ({type: followTypeParam}: {type: Follow}) => {
@@ -51,6 +55,11 @@ const BottomSheetFollow = forwardRef((props: BottomSheetFollowProps, ref: Ref<RB
       try {
         await followTopic(topicName, isIncognito);
         getTopicDetail(topicName);
+        const discoveryInitialTopicResponse = await DiscoveryRepo.fetchInitialDiscoveryTopics();
+        DiscoveryAction.setDiscoveryInitialTopics(
+          discoveryInitialTopicResponse.suggestedTopics as any,
+          discoveryDispatch
+        );
       } catch (error) {
         if (__DEV__) {
           console.log(error);


### PR DESCRIPTION
# Helio PR Checklist

## Please review all of the following checks before making PR

- [x] Jika menambahkan sebuah komponen, apakah sudah dipastikan tidak ada komponen yang redundant, baik secara UI maupun fungsional?
- [x] Periksa apakah komponen yang dibuat reusable (contoh: membuat komponen View untuk membuat Divider antar section)
- [x] Periksa untuk penggunaan state management yang baik dan benar (contoh: Context, useState), terutama penggunaan local state untuk optimistic UI (Pengoperan state dan data melalui props dari parent ke children dan sebaliknya)
- [x] Pastikan komponen yang dibuat sudah sesuai dengan module yang ada terutama penamaan dan penempatan untuk meningkatkan readability dan maintainability.
- [x] Implementasi fallback error untuk menangani kesalahan tak terduga, mencegah aplikasi mengalami crash
- [x] Evaluasi kompleksitas kode dan perbaiki logika yang kompleks dengan memecahnya menjadi fungsi atau komponen yang lebih kecil dan lebih mudah dimengerti.
- [x] Apakah sudah resolve semua komentar dari CodeRabbit🐇?
- [x] Apakah semua unit tests sudah Pass/Success? (Tidak ada bypass)
- [x] Periksa semua perubahan teks Bahasa Inggris approved oleh Bastian?
- [x] Apakah sudah menggunakan normalized.dimen/ normalizeFontSize untuk semua perubahan style?
- [x] Pastikan untuk mengikuti [guidelines pembuatan komponen Guidelines About Loading and Layout](https://docs.google.com/document/d/1GHbvEtFrQmEQXYBV9dLrPI654n2DbPwS1qjedajLSiw/edit)

### Author's comment

if you have any unchecked items, please explain the reason why.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Enhanced the `BottomSheetFollow` component on the Topic Page Screen. Now, it fetches and displays initial discovery topics dynamically, providing users with a more personalized and interactive experience.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->