### PR TITLE
feat: add border

### DIFF
--- a/src/screens/DiscoveryScreenV2/elements/DiscoveryTitleSeparator.js
+++ b/src/screens/DiscoveryScreenV2/elements/DiscoveryTitleSeparator.js
@@ -9,13 +9,14 @@ import {COLORS} from '../../../utils/theme';
  * @property {String} text
  * @property {Boolean} showArrow
  * @property {Boolean} [rotateArrow]
+ * @property {Boolean} [withBorderBottom]
  */
 /**
  *
  * @param {DiscoveryTitleSeparatorProp} props
  */
 const DiscoveryTitleSeparator = (props) => {
-  const {text, showArrow, rotateArrow = false} = props;
+  const {text, showArrow, rotateArrow = false, withBorderBottom = false} = props;
 
   // Animation value for rotation
   const rotation = React.useRef(new Animated.Value(0)).current;
@@ -47,6 +48,8 @@ const DiscoveryTitleSeparator = (props) => {
   return (
     <View
       style={{
+        borderBottomColor: withBorderBottom && !rotateArrow ? COLORS.gray210 : 'transparent',
+        borderBottomWidth: 1,
         backgroundColor: COLORS.gray110,
         justifyContent: 'space-between',
         alignContent: 'center',

--- a/src/screens/DiscoveryScreenV2/fragment/DomainFragment.js
+++ b/src/screens/DiscoveryScreenV2/fragment/DomainFragment.js
@@ -196,6 +196,7 @@ const DomainFragment = ({
     const renderHeader = (data, index) => {
       return (
         <DiscoveryTitleSeparator
+          withBorderBottom={true}
           key="user-title-separator"
           text="Domains you follow"
           showArrow

--- a/src/screens/DiscoveryScreenV2/fragment/TopicFragment.js
+++ b/src/screens/DiscoveryScreenV2/fragment/TopicFragment.js
@@ -122,6 +122,7 @@ const TopicFragment = ({
     const renderHeader = (data, index) => {
       return (
         <DiscoveryTitleSeparator
+          withBorderBottom={true}
           key="user-title-separator"
           text="Your Communities"
           showArrow

--- a/src/screens/DiscoveryScreenV2/fragment/UsersFragment.js
+++ b/src/screens/DiscoveryScreenV2/fragment/UsersFragment.js
@@ -132,6 +132,7 @@ const UsersFragment = ({
     const renderHeader = (data, index) => {
       return (
         <DiscoveryTitleSeparator
+          withBorderBottom={true}
           key="user-title-separator"
           text="People you follow"
           showArrow


### PR DESCRIPTION
# Helio PR Checklist

## Please review all of the following checks before making PR

- [X] Jika menambahkan sebuah komponen, apakah sudah dipastikan tidak ada komponen yang redundant, baik secara UI maupun fungsional?
- [X] Periksa apakah komponen yang dibuat reusable (contoh: membuat komponen View untuk membuat Divider antar section)
- [X] Periksa untuk penggunaan state management yang baik dan benar (contoh: Context, useState), terutama penggunaan local state untuk optimistic UI (Pengoperan state dan data melalui props dari parent ke children dan sebaliknya)
- [X] Pastikan komponen yang dibuat sudah sesuai dengan module yang ada terutama penamaan dan penempatan untuk meningkatkan readability dan maintainability.
- [X] Implementasi fallback error untuk menangani kesalahan tak terduga, mencegah aplikasi mengalami crash
- [X] Evaluasi kompleksitas kode dan perbaiki logika yang kompleks dengan memecahnya menjadi fungsi atau komponen yang lebih kecil dan lebih mudah dimengerti.
- [X] Apakah sudah resolve semua komentar dari CodeRabbit🐇?
- [X] Apakah semua unit tests sudah Pass/Success? (Tidak ada bypass)
- [X] Periksa semua perubahan teks Bahasa Inggris approved oleh Bastian?
- [X] Apakah sudah menggunakan normalized.dimen/ normalizeFontSize untuk semua perubahan style?
- [X] Pastikan untuk mengikuti [guidelines pembuatan komponen Guidelines About Loading and Layout](https://docs.google.com/document/d/1GHbvEtFrQmEQXYBV9dLrPI654n2DbPwS1qjedajLSiw/edit)

### Author's comment

if you have any unchecked items, please explain the reason why.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Enhanced the DiscoveryTitleSeparator component in the Discovery Screen. Users now have the option to include a bottom border for better visual separation and improved user interface experience. This feature is available across Domain, Topic, and User fragments.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->