### PR TITLE
fix: add hasUserPosted on onesignal subscribtion

### DIFF
--- a/__tests__/service/onesignal/OneSignalUtil.test.ts
+++ b/__tests__/service/onesignal/OneSignalUtil.test.ts
@@ -7,7 +7,8 @@ const mockSubscribeableTopicResponse = {
   code: 200,
   data: {
     topics: [{name: 'android'}, {name: 'apple'}],
-    history: [{name: 'android'}, {name: 'apple'}, {name: 'women'}]
+    history: [{name: 'android'}, {name: 'apple'}, {name: 'women'}],
+    hasUserPosted: true
   },
   message: 'Success get topic user',
   status: 'success'
@@ -33,7 +34,7 @@ describe('TESTING OneSignalUtil', () => {
 
       // Assertion
       expect(OneSignal.User.removeTag).toHaveBeenCalledTimes(3);
-      expect(OneSignal.User.addTag).toHaveBeenCalledTimes(2);
+      expect(OneSignal.User.addTag).toHaveBeenCalledTimes(3);
     },
     11 * 1000
   );

--- a/src/service/onesignal/index.ts
+++ b/src/service/onesignal/index.ts
@@ -14,7 +14,7 @@ const SET_TAG_TIMEOUT = 10 * 1000;
 const rebuildAndSubscribeTags = async () => {
   try {
     const response = await getSubscribeableTopic();
-    const {topics = [], history = []} = response?.data || {};
+    const {topics = [], history = [], hasUserPosted} = response?.data || {};
 
     return new Promise((resolve) => {
       history?.forEach((historyItem: TopicTag) => {
@@ -30,6 +30,8 @@ const rebuildAndSubscribeTags = async () => {
 
         resolve(null);
       }, SET_TAG_TIMEOUT);
+
+      OneSignal.User.addTag('has_user_posted', hasUserPosted ? 'true' : 'false');
     });
   } catch (e) {
     console.log('error rebuilding and subscribing tags ', e?.message);


### PR DESCRIPTION
# Helio PR Checklist

## Please review all of the following checks before making PR

- [x] Jika menambahkan sebuah komponen, apakah sudah dipastikan tidak ada komponen yang redundant, baik secara UI maupun fungsional?
- [x] Periksa apakah komponen yang dibuat reusable (contoh: membuat komponen View untuk membuat Divider antar section)
- [x] Periksa untuk penggunaan state management yang baik dan benar (contoh: Context, useState), terutama penggunaan local state untuk optimistic UI (Pengoperan state dan data melalui props dari parent ke children dan sebaliknya)
- [x] Pastikan komponen yang dibuat sudah sesuai dengan module yang ada terutama penamaan dan penempatan untuk meningkatkan readability dan maintainability.
- [x] Implementasi fallback error untuk menangani kesalahan tak terduga, mencegah aplikasi mengalami crash
- [x] Evaluasi kompleksitas kode dan perbaiki logika yang kompleks dengan memecahnya menjadi fungsi atau komponen yang lebih kecil dan lebih mudah dimengerti.
- [x] Apakah sudah resolve semua komentar dari CodeRabbit🐇?
- [x] Apakah semua unit tests sudah Pass/Success? (Tidak ada bypass)
- [x] Periksa semua perubahan teks Bahasa Inggris approved oleh Bastian?
- [x] Apakah sudah menggunakan normalized.dimen/ normalizeFontSize untuk semua perubahan style?
- [x] Pastikan untuk mengikuti [guidelines pembuatan komponen Guidelines About Loading and Layout](https://docs.google.com/document/d/1GHbvEtFrQmEQXYBV9dLrPI654n2DbPwS1qjedajLSiw/edit)

### Author's comment

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- New Feature: Enhanced user tagging in OneSignal service. The system now tags users based on their posting activity, allowing for more personalized notifications.
- Test: Updated tests for the OneSignal service to accommodate the new `hasUserPosted` field and its related functionality.
---
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->