### PR TITLE
fix: mode cover if multiple images post PING-4272

### DIFF
--- a/src/screens/FeedScreen/Content.js
+++ b/src/screens/FeedScreen/Content.js
@@ -7,6 +7,7 @@ import {Dimensions, Platform, Pressable, StyleSheet, Text, View} from 'react-nat
 // eslint-disable-next-line import/no-extraneous-dependencies
 import {useNavigation, useRoute} from '@react-navigation/native';
 
+import FastImage from 'react-native-fast-image';
 import BlurredLayer from './elements/BlurredLayer';
 import ContentPoll from './ContentPoll';
 import ImageLayouter from './elements/ImageLayouter';
@@ -335,6 +336,7 @@ const Content = ({
         {!isBlurredPost && images_url.length > 0 && (
           <View style={[styles.containerImage(isBlurredPost)]}>
             <ImageLayouter
+              mode={FastImage.resizeMode.cover}
               isFeed={true}
               images={images_url}
               onimageclick={() => onPress(showSeeMore)}


### PR DESCRIPTION
# Helio PR Checklist

## Please review all of the following checks before making PR

- [x] Jika menambahkan sebuah komponen, apakah sudah dipastikan tidak ada komponen yang redundant, baik secara UI maupun fungsional?
- [x] Periksa apakah komponen yang dibuat reusable (contoh: membuat komponen View untuk membuat Divider antar section)
- [x] Periksa untuk penggunaan state management yang baik dan benar (contoh: Context, useState), terutama penggunaan local state untuk optimistic UI (Pengoperan state dan data melalui props dari parent ke children dan sebaliknya)
- [x] Pastikan komponen yang dibuat sudah sesuai dengan module yang ada terutama penamaan dan penempatan untuk meningkatkan readability dan maintainability.
- [x] Implementasi fallback error untuk menangani kesalahan tak terduga, mencegah aplikasi mengalami crash
- [x] Evaluasi kompleksitas kode dan perbaiki logika yang kompleks dengan memecahnya menjadi fungsi atau komponen yang lebih kecil dan lebih mudah dimengerti.
- [x] Apakah sudah resolve semua komentar dari CodeRabbit🐇?
- [x] Apakah semua unit tests sudah Pass/Success? (Tidak ada bypass)
- [x] Periksa semua perubahan teks Bahasa Inggris approved oleh Bastian?
- [x] Apakah sudah menggunakan normalized.dimen/ normalizeFontSize untuk semua perubahan style?
- [x] Pastikan untuk mengikuti [guidelines pembuatan komponen Guidelines About Loading and Layout](https://docs.google.com/document/d/1GHbvEtFrQmEQXYBV9dLrPI654n2DbPwS1qjedajLSiw/edit)

### Author's comment

if you have any unchecked items, please explain the reason why.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Performance Improvement: Updated the `ImageLayouter` component in the FeedScreen to use `FastImage.resizeMode.cover`. This change enhances image loading and display performance, providing a smoother user experience when browsing feeds.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->